### PR TITLE
fix: holdings should properly calc provided eth

### DIFF
--- a/rocketwatch/utils/sea_creatures.py
+++ b/rocketwatch/utils/sea_creatures.py
@@ -70,9 +70,8 @@ def get_holding_for_address(address):
                 eth_balance += solidity.to_float(token.results[0]) * price_cache["rpl_price"]
             if "RETH" in contract_name:
                 eth_balance += solidity.to_float(token.results[0]) * price_cache["reth_price"]
-    # get minipool count
-    minipools = rp.call("rocketMinipoolManager.getNodeMinipoolCount", address)
-    eth_balance += minipools * 16
+    # add eth they provided for minipools
+    eth_balance += solidity.to_int(rp.call("rocketNodeStaking.getNodeETHProvided", address))
     # add their staked RPL
     staked_rpl = solidity.to_int(rp.call("rocketNodeStaking.getNodeRPLStake", address))
     eth_balance += staked_rpl * price_cache["rpl_price"]


### PR DESCRIPTION
This fixes the holdings calculation (sea creatures) to account for LEB8.