### PR TITLE
Deduplication Fixes

### DIFF
--- a/rocketwatch/main.cfg.sample
+++ b/rocketwatch/main.cfg.sample
@@ -10,6 +10,7 @@ rocketpool: {
   manual_addresses: {
     rocketStorage: "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
     rocketSignerRegistry: "0xc1062617d10Ae99E09D941b60746182A87eAB38F",
+    rocketExitArbitrage: "0x2631618408497d27D455aBA9c99A6f61eF305559",
     DAIETH_univ3:  "0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8",
     AirSwap:       "0x4572f2554421Bd64Bef1c22c8a81840E8D496BeA",
     yearnPool:     "0x5c0A86A32c129538D62C106Eb8115a8b02358d57",

--- a/rocketwatch/plugins/events/events.py
+++ b/rocketwatch/plugins/events/events.py
@@ -690,10 +690,12 @@ class QueuedEvents(Cog):
                         events.remove(event)
                     tx_aggregates[full_event_name] = amount + _event["args"]["amountOfStETH"]
                 elif full_event_name == "rocketTokenRETH.Transfer":
-                    if "rocketTokenRETH.TokensBurned" in tx_aggregates:
+                    conflicting_events = ["rocketTokenRETH.TokensBurned", "rocketDepositPool.DepositReceived"]
+                    if any((event in tx_aggregates for event in conflicting_events)):
                         events.remove(event)
                         continue
                     if prev_event := tx_aggregates.get(full_event_name, None):
+                        # only keep largest rETH transfer
                         contract = rp.get_contract_by_address(event["address"])
                         _event = aDict(contract.events[event_name]().processLog(event))
                         _prev_event = aDict(contract.events[event_name]().processLog(event))

--- a/rocketwatch/plugins/events/events.py
+++ b/rocketwatch/plugins/events/events.py
@@ -678,6 +678,7 @@ class QueuedEvents(Cog):
 
             for event in tx_events:
                 event_name, full_event_name = get_event_name(event)
+                log.info(f"Processing event {full_event_name}")
 
                 if full_event_name not in events_by_name:
                     events_by_name[full_event_name] = []
@@ -712,10 +713,11 @@ class QueuedEvents(Cog):
                     if vote_event is not None:
                         events.remove(vote_event)
                 elif full_event_name == "MinipoolPrestaked":
-                    assign_event = events_by_name.get("rocketDepositPool.DepositAssigned", [None]).pop()
-                    if assign_event is not None:
-                        events.remove(assign_event)
-                        tx_aggregates["rocketDepositPool.DepositAssigned"] -= 1
+                    for assign_event in events_by_name.get("rocketDepositPool.DepositAssigned", []).copy():
+                        if event["address"] == assign_event["address"]:
+                            events_by_name["rocketDepositPool.DepositAssigned"].remove(assign_event)
+                            events.remove(assign_event)
+                            tx_aggregates["rocketDepositPool.DepositAssigned"] -= 1
                 elif full_event_name in aggregation_attributes:
                     # there is a special aggregated event, remove duplicates
                     if count := tx_aggregates.get(full_event_name, 0):

--- a/rocketwatch/plugins/events/events.py
+++ b/rocketwatch/plugins/events/events.py
@@ -714,7 +714,8 @@ class QueuedEvents(Cog):
                         events.remove(vote_event)
                 elif full_event_name == "MinipoolPrestaked":
                     for assign_event in events_by_name.get("rocketDepositPool.DepositAssigned", []).copy():
-                        if event["address"] == assign_event["address"]:
+                        assigned_minipool = w3.to_checksum_address(assign_event["topics"][1][-20:])
+                        if event["address"] == assigned_minipool:
                             events_by_name["rocketDepositPool.DepositAssigned"].remove(assign_event)
                             events.remove(assign_event)
                             tx_aggregates["rocketDepositPool.DepositAssigned"] -= 1

--- a/rocketwatch/strings/embeds.en.json
+++ b/rocketwatch/strings/embeds.en.json
@@ -565,8 +565,8 @@
         "description": "The supernode's RPL bond target changed from **%{oldRatio}%** to **%{newRatio}%**!"
     },
     "exit_arbitrage_event": {
-        "title": ":moneybag: Large Exit Arbitrage",
-        "description": "%{caller} earned **%{profit} ETH** with a %{amount} ETH flash loan!",
-        "description_small": "%{caller} earned **%{profit} ETH** from an exit arbitrage with %{amount} ETH!"
+        "title": ":money_mouth: Large Exit Arbitrage",
+        "description": "%{caller} earned **%{profit} ETH** using a %{amount} ETH flash loan!",
+        "description_small": ":money_mouth: %{caller} earned **%{profit} ETH** from an exit arbitrage!"
     }
 }


### PR DESCRIPTION
- remove rETH transfer event for large deposits
- don't remove deposit assignments on minipool creation if they dequeue a different pool